### PR TITLE
Update macOS package list

### DIFF
--- a/build-macos.rst
+++ b/build-macos.rst
@@ -29,7 +29,8 @@ Follow the instructions, now you should be able to install the remaining depende
      glm \
      pygobject3 \
      librsvg \
-     meson
+     meson \
+     cmake
 
 Now you can build the project using the ``./scripts/build_macos.sh`` script.
 

--- a/build-macos.rst
+++ b/build-macos.rst
@@ -30,7 +30,8 @@ Follow the instructions, now you should be able to install the remaining depende
      pygobject3 \
      librsvg \
      meson \
-     cmake
+     cmake \
+     adwaita-icon-theme
 
 Now you can build the project using the ``./scripts/build_macos.sh`` script.
 

--- a/build-macos.rst
+++ b/build-macos.rst
@@ -19,19 +19,19 @@ Follow the instructions, now you should be able to install the remaining depende
 ::
 
    brew install \
-     python@3 \
-     llvm \
+     adwaita-icon-theme \
+     cmake \
      eigen \
-     opencascade \
-     pkg-config \
+     glm \
      gtk4 \
      gtkmm4 \
-     glm \
-     pygobject3 \
      librsvg \
+     llvm \
      meson \
-     cmake \
-     adwaita-icon-theme
+     opencascade \
+     pkg-config \
+     pygobject3 \
+     python@3
 
 Now you can build the project using the ``./scripts/build_macos.sh`` script.
 


### PR DESCRIPTION
This PR updates the package list in macOS build instructions:

- `cmake` is added to the list since it is needed to find Open Cascade. When missing, Meson's configure step won't stop but the build will still fail later.
- `adwaita-icon-theme` is added to the list since some icons appear to be missing in the UI unless this package is installed (found out via `GTK_DEBUG=iconfallback`).
- Finally the package list is alphabetically sorted to keep things nice and tidy :)

A corresponding PR syncing this package list with the application's CI is here: https://github.com/dune3d/dune3d/pull/104