### PR TITLE
build macos: add info about GSettings schema path

### DIFF
--- a/build-macos.rst
+++ b/build-macos.rst
@@ -37,6 +37,7 @@ Now you can build the project using the ``./scripts/build_macos.sh`` script.
 
 You should now have the ``dune3d`` executable in the ``build/`` folder.
 
+If you get an error like "No GSettings schemas are installed on the system" make sure ``GSETTINGS_SCHEMA_DIR`` has been set correctly. For example: ``GSETTINGS_SCHEMA_DIR=/opt/homebrew/share/glib-2.0/schemas ./build/dune3d``.
 
 .. note::
-  Building on macOS is still experimental. You might find workarounds for building/linking issues in this project's issues. Also be aware that selection in macOS is broken for now.
+  Building on macOS is still experimental. You might find workarounds for building/linking issues in this project's issues.


### PR DESCRIPTION
I built it according to the docs but got "No GSettings schemas are installed on the system" and it crashed when saving files. I set the environment variable properly and it worked without crashing. I also don't see any issues with selections, so i removed that line.

HTH.